### PR TITLE
Cargo.toml: put comments above, switch to ch32v003j4m6, upgrade crates

### DIFF
--- a/firmware/Cargo.toml
+++ b/firmware/Cargo.toml
@@ -5,32 +5,34 @@ edition = "2021"
 
 [dependencies]
 ch32-hal = { git = "https://github.com/ch32-rs/ch32-hal.git", features = [
-    "ch32v003f4u6",
+    "ch32v003j4m6",
     "embassy",
     "time-driver-tim2",
     "rt",
     "memory-x",
 ] }
-embassy-executor = { version = "0.6.0", features = [
+# or better use nightly, but fails on recent Rust versions
+embassy-executor = { version = "0.6.1", features = [
     "integrated-timers",
     "arch-riscv32",
     "executor-thread",
-    "task-arena-size-128", # or better use nightly, but fails on recent Rust versions
+    "task-arena-size-128",
 ] }
 embassy-time = { version = "0.3.0" }
 qingke-rt = { version = "0.4.0", features = ["highcode"] }
 qingke = "0.4.0"
-
-
-panic-halt = "0.2.0"
 embedded-hal = "1.0.0"
+panic-halt = "1.0.0"
 
 smart-leds = "0.4.0"
 ws2812-delay = { version = "0.1.0", git = "https://github.com/rappet/ws2812-delay-rs.git", features = ["slow"] }
 
 [profile.release]
-strip = false   # symbols are not flashed to the microcontroller, so don't strip them.
-lto = true
-opt-level = "s" # Optimize for size.
+# symbols are not flashed to the microcontroller, so don't strip them.
+strip = false
+# LLVM can perform better optimizations using a single thread
 codegen-units = 1
 panic = "abort"
+lto = true
+# Optimize for size.
+opt-level = "s"


### PR DESCRIPTION
Based on a diff against a freshly bootstrapped project using
https://github.com/ch32-rs/ch32-hal-template
